### PR TITLE
mt6771-common: Drop IORAP props

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -69,7 +69,3 @@ wifi.direct.interface=p2p0
 
 # Zygote
 ro.zygote.preload.enable=0
-
-# Enable IORap I/O Prefetching
-persist.device_config.runtime_native_boot.iorap_perfetto_enable=true
-persist.device_config.runtime_native_boot.iorap_readahead_enable=true


### PR DESCRIPTION
 - IORAP has been dropped from Android as of commit [1]

[1]: https://android-review.googlesource.com/c/platform/system/iorap/+/2025264

Change-Id: I28273830d32bad3ab1faaf61e3771301762a386a
Signed-off-by: kawaaii <kawaaii@nocturn9x.space>