### PR TITLE
mt6771-common: Drop EXTRA VNDK Flag

### DIFF
--- a/mt6771-common.mk
+++ b/mt6771-common.mk
@@ -253,8 +253,6 @@ PRODUCT_COPY_FILES += \
     prebuilts/vndk/v28/arm64/arch-arm64-armv8-a/shared/vndk-sp/libutils.so:$(TARGET_COPY_OUT_VENDOR)/lib64/libutils-v28.so \
     prebuilts/vndk/v30/arm64/arch-arm64-armv8-a/shared/vndk-sp/libutils.so:$(TARGET_COPY_OUT_VENDOR)/lib64/libutils-v30.so
 
-PRODUCT_EXTRA_VNDK_VERSIONS := 28
-
 # WiFi
 PRODUCT_PACKAGES += \
     android.hardware.wifi@1.4.vendor \


### PR DESCRIPTION
* not needed in Prebuilt vendor